### PR TITLE
Add stock location filter on shipping method page

### DIFF
--- a/backend/app/assets/javascripts/spree/backend.js
+++ b/backend/app/assets/javascripts/spree/backend.js
@@ -52,6 +52,7 @@
 //= require spree/backend/shipments
 //= require spree/backend/spree-select2
 //= require spree/backend/stock_management
+//= require spree/backend/stock_location_filter
 //= require spree/backend/store_credits
 //= require spree/backend/style_guide
 //= require spree/backend/taxon_autocomplete

--- a/backend/app/assets/javascripts/spree/backend/stock_location_filter.js
+++ b/backend/app/assets/javascripts/spree/backend/stock_location_filter.js
@@ -1,0 +1,13 @@
+Spree.ready(function() {
+  var $shippingMethodAvailableToAll = $('#shipping_method_available_to_all');
+
+  function showStockLocationCheckboxes() {
+    $('#shipping_method_stock_locations_field').toggleClass('hidden', $shippingMethodAvailableToAll.is(':checked'));
+  }
+
+  $shippingMethodAvailableToAll.change(function(event){
+    showStockLocationCheckboxes();
+  });
+
+  showStockLocationCheckboxes();
+});

--- a/backend/app/views/spree/admin/shipping_methods/_form.html.erb
+++ b/backend/app/views/spree/admin/shipping_methods/_form.html.erb
@@ -81,6 +81,31 @@
       </fieldset>
     </div>
 
+    <div data-hook="admin_stock_locations_form_fields">
+      <fieldset class="no-border-bottom">
+        <legend align="center"><%= plural_resource_name(Spree::StockLocation) %></legend>
+        <%= f.field_container :available_to_all, class: %w(checkbox) do %>
+          <label>
+            <%= f.check_box(:available_to_all) %>
+            <%= Spree::ShippingMethod.human_attribute_name :available_to_all %>
+          </label>
+          <%= error_message_on :shipping_method, :available_to_all %>
+        <% end %>
+
+        <%= f.field_container :stock_locations do %>
+        <% shipping_method_stock_locations = @shipping_method.stock_locations.to_a %>
+          <% Spree::StockLocation.all.each do |stock_location| %>
+            <label>
+              <%= check_box_tag('shipping_method[stock_location_ids][]', stock_location.id, shipping_method_stock_locations.include?(stock_location)) %>
+              <%= stock_location.name %>
+            </label>
+            <br>
+          <% end %>
+          <%= error_message_on :shipping_method, :stock_locations %>
+        <% end %>
+      </fieldset>
+    </div>
+
     <div>
       <fieldset class="no-border-bottom">
         <legend align="center"><%= plural_resource_name(Spree::Zone) %></legend>


### PR DESCRIPTION
Thanks to this [PR](https://github.com/solidusio/solidus/pull/412) is possible to restrict shipping methods by stock location( #391 ), but the admin code was missed in the admin interface.
This PR is going to add this ability under the shipping method edit page.

<img width="1195" alt="Screenshot 2019-10-25 at 17 34 21" src="https://user-images.githubusercontent.com/387690/67585462-d9333680-f74f-11e9-9f7f-24766a9ea3cb.png">
<img width="1184" alt="Screenshot 2019-10-25 at 17 34 33" src="https://user-images.githubusercontent.com/387690/67585476-e18b7180-f74f-11e9-94da-f98c2cff0e04.png">


**Checklist:**
- [X] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [ ] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
